### PR TITLE
Require a space before function parenthesis for async arrow functions

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -19,7 +19,11 @@ module.exports = {
         'object-shorthand': 'error',
         'quote-props': [ 'error', 'consistent-as-needed' ],
         'quotes': [ 'error', 'single' ],
-        'space-before-function-paren': [ 'error', 'never' ],
+        'space-before-function-paren': [ 'error', {
+            'anonymous': 'never',
+            'named': 'never',
+            'asyncArrow': 'always'
+        }],
         'spaced-comment': [ 'error', 'always', { block: { balanced: true } } ],
         'strict': [ 'error', 'global' ]
     }


### PR DESCRIPTION
Before:

```
const f = async() => {};
```

After:

```
const f = async () => {};
```